### PR TITLE
Fix dependency error when running jest, add missing jest-enzyme

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "react-dom": "16.4.1",
     "react-hot-loader": "4.3.3"
   },
+  "resolutions": {
+    "babel-core": "7.0.0-bridge.0"
+  },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.54",
     "@babel/plugin-proposal-class-properties": "7.0.0-beta.54",
@@ -84,6 +87,7 @@
     "husky": "0.14.3",
     "identity-obj-proxy": "3.0.0",
     "jest": "23.4.1",
+    "jest-enzyme": "^6.0.2",
     "lint-staged": "7.2.0",
     "mini-css-extract-plugin": "0.4.1",
     "node-sass": "4.9.2",


### PR DESCRIPTION
Kept getting 
Migrate to babel 7: Requires Babel "^7.0.0-0" but was loaded with ... " 

This helped https://github.com/babel/babel/issues/8206
Also, jest-enzyme was missing as dependency for setupTests.js
